### PR TITLE
ci(circleci): added deploy and failure notifications (CORE-4986)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,18 @@ defaults:
         ignore: /.*/
       tags:
         only: /^v[0-9]*(\.[0-9]*)*$/
+  slack-fail-post-step: &slack-fail-post-step
+    post-steps:
+      - vfcommon/notify_slack:
+          channel: dev_general
+          event: fail
+          mentions: "@eng_runtime"
+          template: basic_fail_1
+          branch_pattern: master
 
 orbs:
   codecov: codecov/codecov@1.0.2
-  vfcommon: voiceflow/common@0.0.64
+  vfcommon: voiceflow/common@0.0.66
   sonarcloud: sonarsource/sonarcloud@1.0.2
   validate-title: qventus/validate-title@0.0.4
 
@@ -121,6 +129,7 @@ workflows:
   test-and-release-app::
     jobs:
       - test:
+          <<: *slack-fail-post-step
           context: dev-test
           filters:
             branches:
@@ -128,6 +137,7 @@ workflows:
                 - /env-.*/
                 - staging
       - vfcommon/release:
+          <<: *slack-fail-post-step
           context: dev-test
           requires:
             - test


### PR DESCRIPTION
**Fixes or implements CORE-4986**

### Brief description. What is this change?

Added build failures notification on master branch and move slack notifications to the orb



### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded